### PR TITLE
Update docs: change 'DenseNetwork' -> 'FCNet'

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,10 +1,10 @@
 
 All models inherit from ``torch.nn.Module``—either directly or through ``torch.nn.Sequential``—and therefore function like standard `PyTorch <https://pytorch.org/>`_ models.
 
-DenseNetwork
+FCNet
 ==================
 
-.. automodule:: torch_tools.models._dense_network
+.. automodule:: torch_tools.models._fc_net
    :members:
 
 ConvNet2d


### PR DESCRIPTION
The rst/html files have the old name for this model; it needs changing.

Closes #32.