### PR TITLE
:pencil2: :memo: Fix docstring typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 
 ### Documentation
-- Fixed a typo in the docstring for ``torch_tools.models._argument_processing.process_dropout_prob``. The ``prob`` arg should be on ``[0.0, 1.0)``, and not ``(0.0, 1.0]`` as described. This was only a docstring-typo and not a bug.
+- Fixed a typo in the docstring for ``torch_tools.models._argument_processing.process_dropout_prob``. The ``prob`` arg should be on ``[0.0, 1.0)``, and not ``(0.0, 1.0]`` as described. This was only a typo in the docstring and not a bug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Version 0.2.0
+
+
+### Documentation
+- Fixed a typo in the docstring for ``torch_tools.models._argument_processing.process_dropout_prob``. The ``prob`` arg should be on ``[0.0, 1.0)``, and not ``(0.0, 1.0]`` as described. This was only a docstring-typo and not a bug.

--- a/torch_tools/models/_argument_processing.py
+++ b/torch_tools/models/_argument_processing.py
@@ -64,7 +64,7 @@ def process_dropout_prob(prob: float) -> float:
     Parameters
     ----------
     prob : float
-        Dropout probability.
+        Dropout probability. Should be on [0.0, 1.0).
 
     Returns
     -------
@@ -76,7 +76,7 @@ def process_dropout_prob(prob: float) -> float:
     TypeError
         If `prob` is not a float.
     ValueError
-        If `prob` is not (0.0, 1.0].
+        If `prob` is not [0.0, 1.0).
 
     """
     if not isinstance(prob, float):


### PR DESCRIPTION
Closes #48.

Fixed the typo in the docstring and updated ``CHANGELOG.md``.