### PR TITLE
Fix docs typo on FCNet.

### DIFF
--- a/src/torch_tools/models/_fc_net.py
+++ b/src/torch_tools/models/_fc_net.py
@@ -39,7 +39,7 @@ class FCNet(Sequential):
 
     Examples
     --------
-    >>> from torch_tools import DenseNetwork
+    >>> from torch_tools import FCNet
     >>> FCNet(in_feats=256,
               out_feats=2,
               hidden_sizes=(128, 64, 32),


### PR DESCRIPTION
Closes #69 

Tiny fix.
Updated example in docstring of `FCNet` in `_fc_net.py`

:)